### PR TITLE
Fix adding ORDER BY column into SELECT DISTINCT

### DIFF
--- a/pg4wp/driver_pgsql.php
+++ b/pg4wp/driver_pgsql.php
@@ -287,17 +287,17 @@ function pg4wp_rewrite($sql)
         }
 
         // Ensure that ORDER BY column appears in SELECT DISTINCT fields
-        $pattern = '/^SELECT DISTINCT.*ORDER BY\s+(\S+)/';
+        $pattern = '/SELECT DISTINCT.*ORDER BY\s+(\S+)/s';
         if (
             preg_match($pattern, $sql, $matches)
             && strpos($sql, $matches[1]) > strpos($sql, 'ORDER BY')
             && false === strpos($sql, '*')
         ) {
             if (false !== strpos($sql, 'GROUP BY')) {
-                $pattern = '/ FROM /';
+                $pattern = '/\sFROM\s/';
                 $sql = preg_replace($pattern, ', MIN(' . $matches[1] . ') AS ' . $matches[1] . ' FROM ', $sql, 1);
             } else {
-                $pattern = '/ FROM /';
+                $pattern = '/\sFROM\s/';
                 $sql = preg_replace($pattern, ', ' . $matches[1] . ' FROM ', $sql, 1);
             }
         }


### PR DESCRIPTION
This fixes the error on WP 6.0.3:

```
[1666281430.1221] Error running :

                        SELECT DISTINCT t.term_id, tr.object_id
                        FROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp_term_relationships AS t\
r ON tr.term_taxonomy_id = tt.term_taxonomy_id
                        WHERE tt.taxonomy IN ('wp_theme') AND tr.object_id IN (7)
                        ORDER BY t.name ASC


---- converted to ----
SELECT DISTINCT t.term_id, tr.object_id
                        FROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp_term_relationships AS t\
r ON tr.term_taxonomy_id = tt.term_taxonomy_id
                        WHERE tt.taxonomy IN ('wp_theme') AND tr.object_id IN (7)
                        ORDER BY t.name ASC
----> ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 4:    ORDER BY t.name ASC
                    ^
---------------------
```